### PR TITLE
`lspoints#attach()`の`options`引数に`cmdOptions`フィールドを追加

### DIFF
--- a/denops/lspoints/client.ts
+++ b/denops/lspoints/client.ts
@@ -60,7 +60,10 @@ export class LanguageClient {
     if (startOptions.cmd == null) {
       throw "cmd not specify";
     }
-    this.rpcClient = new JsonRpcClient(startOptions.cmd);
+    this.rpcClient = new JsonRpcClient(
+      startOptions.cmd,
+      startOptions.cmdOptions,
+    );
   }
 
   async initialize(settings: Settings) {

--- a/denops/lspoints/interface.ts
+++ b/denops/lspoints/interface.ts
@@ -8,6 +8,7 @@ type Promisify<T> = T | Promise<T>;
 
 export const isStartOptions = u.isObjectOf({
   cmd: u.isOptionalOf(u.isArrayOf(u.isString)),
+  cmdOptions: u.isOptionalOf(u.isRecordOf(u.isUnknown)),
   initializationOptions: u.isOptionalOf(u.isRecord),
   params: u.isOptionalOf(u.isRecord),
   rootPath: u.isOptionalOf(u.isString),

--- a/denops/lspoints/jsonrpc/jsonrpc_client.ts
+++ b/denops/lspoints/jsonrpc/jsonrpc_client.ts
@@ -63,8 +63,12 @@ export class JsonRpcClient {
   > = [];
   logger = new Logger();
 
-  constructor(command: string[]) {
+  constructor(
+    command: string[],
+    options?: Record<string, unknown>,
+  ) {
     this.#process = new Deno.Command(command[0], {
+      ...options,
       args: command.slice(1),
       stdin: "piped",
       stdout: "piped",

--- a/doc/lspoints.jax
+++ b/doc/lspoints.jax
@@ -55,6 +55,10 @@ lspoints#attach({name}, [{options}])
 
 	cmd:
 		サーバーを起動するためのコマンドライン。文字列のリスト。
+	cmdOptions:
+		サーバーを起動する際に `Deno.Command()` の `options` 引数に渡
+		す辞書です。ただし `args`, `stdin`, `stdout`, `sterr`の4つの
+		フィールドの値は内部的に決定されます。
 	initializationOptions:
 		サーバーに渡される初期化オプション
 


### PR DESCRIPTION
`cmdOptions`フィールドに[`Deno.CommandOptions`](https://deno.land/api@v1.40.5?s=Deno.CommandOptions)相当の辞書を渡せるようにしました。
以下のようなことが可能になります。

```ts
{
  clearEnv: true, // denopsやVimで設定された環境変数の初期化
  env: { DENO_DIR: "/tmp/hoge" } // 環境変数の上書き
  cwd: "/tmp/fuga" // LSを起動する作業ディレクトリの指定
}
```
