### PR TITLE
Use shiftwidth() instead of &l:shiftwidth

### DIFF
--- a/denops/@lspoints/format.ts
+++ b/denops/@lspoints/format.ts
@@ -33,7 +33,7 @@ export class Extension extends BaseExtension {
               uri: "file://" + path,
             },
             options: {
-              tabSize: Number(await denops.eval("&l:shiftwidth")),
+              tabSize: Number(await denops.call("shiftwidth")),
               insertSpaces: Boolean(await denops.eval("&l:expandtab")),
             },
           },


### PR DESCRIPTION
shiftwidth() is preferred to get the indent width.