### PR TITLE
fix: Allow pass interface to ArrayOrObject

### DIFF
--- a/denops/lspoints/interface.ts
+++ b/denops/lspoints/interface.ts
@@ -5,7 +5,8 @@ import { as, is, type Predicate } from "./deps/unknownutil.ts";
 
 type Promisify<T> = T | Promise<T>;
 
-type ArrayOrObject = Array<unknown> | Record<string, unknown>;
+// deno-lint-ignore no-explicit-any
+type ArrayOrObject = Array<unknown> | Record<PropertyKey, any>;
 
 export type StartOptions = {
   cmd?: string[];

--- a/denops/lspoints/jsonrpc/message.ts
+++ b/denops/lspoints/jsonrpc/message.ts
@@ -2,7 +2,7 @@ import { as, is, type PredicateType } from "../deps/unknownutil.ts";
 
 export const isArrayOrObject = is.UnionOf([
   is.Array,
-  is.Record,
+  is.RecordOf(is.Any),
 ]);
 
 export type ArrayOrObject = PredicateType<typeof isArrayOrObject>;


### PR DESCRIPTION
SSIA

```ts
type TFoo = { x: number; };
interface IFoo { x: number; }

const tFoo: TFoo = { x: 1 };
const iFoo: IFoo = { x: 1 };

lspoints.getClient("ls")!.request("hoge/fuga", tFoo); // 通る
lspoints.getClient("ls")!.request("hoge/fuga", iFoo); // 通らない
```