### PR TITLE
feat: Add support for stopping LSP server and handling LSP server exits.

### DIFF
--- a/autoload/lspoints.vim
+++ b/autoload/lspoints.vim
@@ -18,6 +18,10 @@ function lspoints#attach(name, options = {}) abort
   call lspoints#denops#notify('attach', [a:name, bufnr])
 endfunction
 
+function lspoints#detach(name) abort
+  call lspoints#denops#notify('detach', [a:name])
+endfunction
+
 function lspoints#load_extensions(pathes) abort
   call extend(g:lspoints#extensions, a:pathes)
   if denops#plugin#is_loaded('lspoints')

--- a/denops/@lspoints/nvim_diagnostics.ts
+++ b/denops/@lspoints/nvim_diagnostics.ts
@@ -32,5 +32,11 @@ export class Extension extends BaseExtension {
         });
       },
     );
+    lspoints.subscribeDetach(async (client) => {
+      await denops.call(
+        "luaeval",
+        `require('lspoints').reset_diagnostics('${client}')`,
+      );
+    });
   }
 }

--- a/denops/lspoints/app.ts
+++ b/denops/lspoints/app.ts
@@ -35,6 +35,10 @@ export const main: Entrypoint = async (denops: Denops) => {
       assert(bufNr, is.Number);
       await lspoints.attach(denops, id, bufNr);
     },
+    detach(id: unknown) {
+      assert(id, isNumberOrString);
+      lspoints.detach(id);
+    },
     async notifyChange(
       bufNr: unknown,
       uri: unknown,

--- a/denops/lspoints/app.ts
+++ b/denops/lspoints/app.ts
@@ -89,6 +89,7 @@ export const main: Entrypoint = async (denops: Denops) => {
   await autocmd.group(denops, "lspoints.internal", (helper) => {
     helper.remove("*");
     helper.define("User", "LspointsAttach:*", ":");
+    helper.define("User", "LspointsDetach:*", ":");
   });
   await loadBuiltins(denops, lspoints);
   await denops.dispatcher.loadExtensions(

--- a/denops/lspoints/builtin/diagnostics.ts
+++ b/denops/lspoints/builtin/diagnostics.ts
@@ -43,6 +43,9 @@ export class Extension extends BaseExtension {
         }
       },
     );
+    lspoints.subscribeDetach((clientName) => {
+      this.diagnostics.delete(clientName);
+    });
     lspoints.defineCommands("lspoints.diagnostics", {
       get: () => this.diagnostics,
       getFlat: () => {

--- a/denops/lspoints/client.ts
+++ b/denops/lspoints/client.ts
@@ -111,6 +111,10 @@ export class LanguageClient {
     }
   }
 
+  getAttachedBufNrs(): number[] {
+    return Object.keys(this.#attachedBuffers).map(Number);
+  }
+
   getUriFromBufNr(bufNr: number) {
     return this.#attachedBuffers[bufNr] ?? "";
   }

--- a/denops/lspoints/deps/denops.ts
+++ b/denops/lspoints/deps/denops.ts
@@ -1,2 +1,3 @@
 export * as autocmd from "jsr:@denops/std@^7.0.0/autocmd";
 export type { Denops, Entrypoint } from "jsr:@denops/std@^7.0.0";
+export { batch } from "jsr:@denops/std@^7.0.0/batch";

--- a/denops/lspoints/interface.ts
+++ b/denops/lspoints/interface.ts
@@ -38,6 +38,7 @@ export type Client = {
     options?: { signal: AbortSignal },
   ) => Promise<unknown>;
   serverCapabilities: LSP.ServerCapabilities;
+  getAttachedBufNrs(): number[];
   getUriFromBufNr(bufnr: number): string;
   getDocumentVersion(bufnr: number): number;
   isAttached(bufnr: number): boolean;
@@ -52,6 +53,8 @@ export type Settings = {
 };
 
 export type AttachCallback = (clientName: string) => Promisify<void>;
+
+export type DetachCallback = (clientName: string) => Promisify<void>;
 
 export type NotifyCallback = (
   clientName: string,
@@ -86,6 +89,8 @@ export interface Lspoints {
   ): Promise<unknown>;
 
   subscribeAttach(callback: AttachCallback): void;
+
+  subscribeDetach(callback: DetachCallback): void;
 
   subscribeNotify(
     method: string,

--- a/denops/lspoints/lspoints.ts
+++ b/denops/lspoints/lspoints.ts
@@ -215,6 +215,16 @@ export class Lspoints {
     await autocmd.emit(denops, "User", `LspointsAttach:${name}`);
   }
 
+  detach(id: string | number) {
+    const client = this.#getClient(id);
+    if (!client) {
+      throw Error(`client "${id}" is not started`);
+    }
+    client.kill();
+    // detachHandler removes this client from this.clients and this.clientIDs.
+    // We don't need to handle these here.
+  }
+
   async notifyChange(
     bufNr: number,
     uri: string,

--- a/doc/lspoints.jax
+++ b/doc/lspoints.jax
@@ -72,6 +72,10 @@ lspoints#attach({name}, [{options}])
 	使用されます。立ち上がっている場合は無視されるため、省略も可能です。
 	|lspoints#start()| に渡されます。
 
+                                                           *lspoints#detach()*
+lspoints#detach({name})
+	{name} で示される言語サーバーのアタッチを解除します。
+
                                                   *lspoints#load_extensions()*
 lspoints#load_extensions({pathes})
 	{pathes} に指定されたリストを|g:lspoints#extensions|に追加し、

--- a/lua/lspoints.lua
+++ b/lua/lspoints.lua
@@ -20,4 +20,10 @@ function M.notify(msg)
   vim.diagnostic.set(namespace, msg.bufnr, msg.diagnostics)
 end
 
+function M.reset_diagnostics(client)
+  if namespaces[client] ~= nil then
+    vim.diagnostic.reset(namespaces[client])
+  end
+end
+
 return M


### PR DESCRIPTION
- Add `lspoints#detach` function to stop a LSP server.
- Add `LspointsDetach:{server-name}` autocmd to know LSP server exit.
- Add internal `subscribeDetach` API to define callback invoked when LSP server exits.

This feature is useful to settle some states/configurations related to LSP features, e.g. clear diagnostics on buffer.