### PR TITLE
feat: Add support for accessing attached buffer number via subscribeAttach callback or LspointsAttach autocmd

### DIFF
--- a/denops/lspoints/builtin/configuration.ts
+++ b/denops/lspoints/builtin/configuration.ts
@@ -16,7 +16,7 @@ function getSettings(
 
 export class Extension extends BaseExtension {
   initialize(_denops: Denops, lspoints: Lspoints) {
-    lspoints.subscribeAttach(async (clientName) => {
+    lspoints.subscribeAttach(async (clientName, _bufnr) => {
       const settings = getSettings(lspoints, clientName);
       if (settings == null) {
         return;

--- a/denops/lspoints/interface.ts
+++ b/denops/lspoints/interface.ts
@@ -51,7 +51,10 @@ export type Settings = {
   tracePath?: string;
 };
 
-export type AttachCallback = (clientName: string) => Promisify<void>;
+export type AttachCallback = (
+  clientName: string,
+  bufnr: number,
+) => Promisify<void>;
 
 export type NotifyCallback = (
   clientName: string,

--- a/denops/lspoints/lspoints.ts
+++ b/denops/lspoints/lspoints.ts
@@ -188,7 +188,7 @@ export class Lspoints {
         );
       },
     );
-    await autocmd.emit(denops, "User", `LspointsAttach:${name}`);
+    await autocmd.emit(denops, "User", `LspointsAttach:${name}:${bufNr}`);
   }
 
   async notifyChange(

--- a/denops/lspoints/lspoints.ts
+++ b/denops/lspoints/lspoints.ts
@@ -174,7 +174,7 @@ export class Lspoints {
       await client.attach(bufNr);
     });
     for (const handler of this.attachHandlers) {
-      await handler(name);
+      await handler(name, bufNr);
     }
     await autocmd.group(
       denops,


### PR DESCRIPTION
This PR adds support for getting attached buffer number information while hooks invoked when LSP is attached to some buffer:
- Callbacks of subscribeAttach is fired with two arguments: client name and attached buffer number.
- LspointsAttach autocmd is fired in this form: `LspointsAttach:{server-name}:{attached-buffer-number}`

Please tell me if we should use another style for the accessing way of bufnr, e.g. give a utility function/variable to get attached bufnr information instead of changing LspointsAttach autocmd pattern.